### PR TITLE
Fix validation for word and phrase analysis outputs

### DIFF
--- a/api/app/schemas/text.py
+++ b/api/app/schemas/text.py
@@ -1,6 +1,18 @@
 """Module for defining Pydantic models for text analysis API endpoints."""
-from typing import List, Dict
+from typing import List
 from pydantic import BaseModel, confloat, constr
+
+
+class WordFrequency(BaseModel):
+    """Frequency information for a single word."""
+    word: str
+    frequency: confloat(ge=0, le=1)  # Frequency as a fraction between 0 and 1
+
+
+class MatchedPhrase(BaseModel):
+    """Representation of a phrase matched in the analysed text."""
+    phrase: str
+    ai_likelihood: confloat(ge=0, le=1)
 
 class TextAnalysisRequest(BaseModel):
     """Pydantic model for the request body of the text analysis endpoint."""
@@ -10,14 +22,14 @@ class WordAnalysis(BaseModel):
     """Pydantic model for word analysis."""
     total_word_count: int
     unique_word_count: int
-    word_frequencies: List[Dict[str, confloat(ge=0, le=1)]]  # Frequency as a fraction between 0 and 1
+    word_frequencies: List[WordFrequency]
     top_n_words: List[str]
     ai_likelihood: confloat(ge=0, le=1)  # AI likelihood should be between 0 and 1
 
 class PhraseAnalysis(BaseModel):
     """Pydantic model for phrase analysis."""
     total_phrase_count: int
-    matched_ai_phrases: List[Dict[str, confloat(ge=0, le=1)]]
+    matched_ai_phrases: List[MatchedPhrase]
     ai_likelihood: confloat(ge=0, le=1)  # AI likelihood should be between 0 and 1
 
 class TextAnalysisResponse(BaseModel):

--- a/api/app/services/text_analysis.py
+++ b/api/app/services/text_analysis.py
@@ -1,13 +1,19 @@
 """This module contains the text analysis service functions."""
 import os
 from collections import Counter
+from typing import List
 
 import nltk
 from nltk.tokenize import word_tokenize
 from sqlalchemy.orm import Session
 
 from app.db import models
-from app.schemas.text import TextAnalysisResponse, WordAnalysis, PhraseAnalysis
+from app.schemas.text import (
+    TextAnalysisResponse,
+    WordAnalysis,
+    PhraseAnalysis,
+    MatchedPhrase,
+)
 
 # Set NLTK data path
 nltk.data.path.append(os.environ.get('NLTK_DATA', '/app/nltk_data'))
@@ -59,10 +65,10 @@ def calculate_word_ai_likelihood(words, db_words):
     )
 
 
-def find_matched_phrases(text, db_phrases):
+def find_matched_phrases(text, db_phrases) -> List[MatchedPhrase]:
     """Find and return matched AI-generated phrases in the text."""
     return [
-        {"phrase": phrase.phrase, "ai_likelihood": phrase.ai_likelihood}
+        MatchedPhrase(phrase=phrase.phrase, ai_likelihood=phrase.ai_likelihood)
         for phrase in db_phrases
         if phrase.phrase.lower() in text.lower()
     ]
@@ -72,8 +78,7 @@ def calculate_phrase_ai_likelihood(text, db_phrases):
     """Calculate the AI likelihood of the given phrases."""
     matched_phrases = find_matched_phrases(text, db_phrases)
     return (
-        sum(phrase["ai_likelihood"] for phrase in matched_phrases)
-        / len(matched_phrases)
+        sum(phrase.ai_likelihood for phrase in matched_phrases) / len(matched_phrases)
         if matched_phrases
         else 0
     )


### PR DESCRIPTION
## Summary
- add explicit `WordFrequency` and `MatchedPhrase` models to schema
- ensure text analysis service returns typed phrase matches

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895385c55308330a5e0bbe67a7cd060