### PR TITLE
Enhance text analysis service documentation and mark completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker-compose up -d
 
 [x] Swagger
 
-[] Text Analysis Service
+[x] Text Analysis Service
 
 [x] Database Models
 

--- a/api/app/services/text_analysis.py
+++ b/api/app/services/text_analysis.py
@@ -1,29 +1,54 @@
-"""This module contains the text analysis service functions."""
+"""Utility functions for analyzing text and detecting AI-generated content.
+
+The service provides basic natural language processing (NLP) features using
+`nltk` for tokenization and leverages the database to look up known words and
+phrases that are commonly produced by AI systems. Each helper is documented
+with its purpose and expected inputs to make the implementation clear and
+maintainable.
+"""
 import os
 from collections import Counter
 from typing import List
 
 import nltk
-from nltk.tokenize import word_tokenize
+from nltk.tokenize import sent_tokenize, word_tokenize
 from sqlalchemy.orm import Session
 
 from app.db import models
 from app.schemas.text import (
+    MatchedPhrase,
+    PhraseAnalysis,
     TextAnalysisResponse,
     WordAnalysis,
-    PhraseAnalysis,
-    MatchedPhrase,
 )
 
 # Set NLTK data path
-nltk.data.path.append(os.environ.get('NLTK_DATA', '/app/nltk_data'))
+nltk.data.path.append(os.environ.get("NLTK_DATA", "/app/nltk_data"))
 
 
 def analyze_text(text: str, db: Session) -> TextAnalysisResponse:
-    """Analyze the given text for AI-generated content."""
-    words = word_tokenize(text.lower())
+    """Perform NLP analysis on ``text`` and compute AI-likelihood metrics.
+
+    The function tokenizes the incoming text, gathers frequency statistics, and
+    queries the database for previously observed AI-generated words and phrases.
+    Results are aggregated into :class:`TextAnalysisResponse` which contains
+    granular information about words and phrases as well as an overall
+    likelihood score.
+
+    Parameters
+    ----------
+    text:
+        Text to analyse.
+    db:
+        SQLAlchemy session used for retrieving known words and phrases.
+    """
+
+    # Tokenize and normalise text. ``word_tokenize`` returns punctuation which
+    # we filter out to avoid skewing statistics.
+    words = [w for w in word_tokenize(text.lower()) if w.isalpha()]
     word_freq = Counter(words)
 
+    # Retrieve known AI words/phrases from the database once for reuse.
     db_words = db.query(models.Word).all()
     db_phrases = db.query(models.Phrase).all()
 
@@ -39,7 +64,7 @@ def analyze_text(text: str, db: Session) -> TextAnalysisResponse:
     )
 
     phrase_analysis = PhraseAnalysis(
-        total_phrase_count=len(text.split(".")),
+        total_phrase_count=len(sent_tokenize(text)),
         matched_ai_phrases=find_matched_phrases(text, db_phrases),
         ai_likelihood=calculate_phrase_ai_likelihood(text, db_phrases),
     )
@@ -55,8 +80,26 @@ def analyze_text(text: str, db: Session) -> TextAnalysisResponse:
     )
 
 
-def calculate_word_ai_likelihood(words, db_words):
-    """Calculate the AI likelihood of the given words."""
+def calculate_word_ai_likelihood(
+    words: List[str], db_words: List[models.Word]
+) -> float:
+    """Return the average AI likelihood for all ``words``.
+
+    Parameters
+    ----------
+    words:
+        Tokenised words extracted from the analysed text.
+    db_words:
+        List of :class:`~app.db.models.Word` instances fetched from the
+        database.
+
+    Returns
+    -------
+    float
+        Average ``ai_likelihood`` of matched words, or ``0`` when no matches
+        are found.
+    """
+
     ai_words = [db_word for db_word in db_words if db_word.word in words]
     return (
         sum(word.ai_likelihood for word in ai_words) / len(ai_words)
@@ -65,8 +108,20 @@ def calculate_word_ai_likelihood(words, db_words):
     )
 
 
-def find_matched_phrases(text, db_phrases) -> List[MatchedPhrase]:
-    """Find and return matched AI-generated phrases in the text."""
+def find_matched_phrases(
+    text: str, db_phrases: List[models.Phrase]
+) -> List[MatchedPhrase]:
+    """Find phrases from the database that occur within ``text``.
+
+    Parameters
+    ----------
+    text:
+        Raw text being analysed.
+    db_phrases:
+        List of :class:`~app.db.models.Phrase` instances available in the
+        database.
+    """
+
     return [
         MatchedPhrase(phrase=phrase.phrase, ai_likelihood=phrase.ai_likelihood)
         for phrase in db_phrases
@@ -74,8 +129,26 @@ def find_matched_phrases(text, db_phrases) -> List[MatchedPhrase]:
     ]
 
 
-def calculate_phrase_ai_likelihood(text, db_phrases):
-    """Calculate the AI likelihood of the given phrases."""
+def calculate_phrase_ai_likelihood(
+    text: str, db_phrases: List[models.Phrase]
+) -> float:
+    """Return the average AI likelihood of phrases present in ``text``.
+
+    Parameters
+    ----------
+    text:
+        Raw text being analysed.
+    db_phrases:
+        List of :class:`~app.db.models.Phrase` instances fetched from the
+        database.
+
+    Returns
+    -------
+    float
+        Average ``ai_likelihood`` of matched phrases, or ``0`` if no database
+        phrases are found within the text.
+    """
+
     matched_phrases = find_matched_phrases(text, db_phrases)
     return (
         sum(phrase.ai_likelihood for phrase in matched_phrases) / len(matched_phrases)


### PR DESCRIPTION
## Summary
- expand NLP utilities for text and phrase analysis with detailed docstrings
- tokenize words and sentences using NLTK and calculate AI-likelihoods via database lookups
- update README to mark the Text Analysis Service task as finished

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689540f4b3f0833090af4ca6578f5655