### PR TITLE
Add error handling to text analysis endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ docker-compose up -d
 [x] Database Connection and ORM Setup
 
 [x] Running with Uvicorn
-
-[] Text Analysis Endpoints
+[x] Text Analysis Endpoints
 
 [] Testing the API
 

--- a/api/app/api/endpoints/text_analysis.py
+++ b/api/app/api/endpoints/text_analysis.py
@@ -1,6 +1,8 @@
 """API endpoint for text analysis."""
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
 from app.api.dependencies import get_db
 from app.schemas.text import TextAnalysisRequest, TextAnalysisResponse
 from app.services.text_analysis import analyze_text
@@ -17,4 +19,12 @@ async def analyze(request: TextAnalysisRequest, db: Session = Depends(get_db)):
     Returns a detailed analysis of the text, including word analysis, phrase analysis,
     and overall AI likelihood.
     """
-    return analyze_text(request.text, db)
+    if not request.text.strip():
+        raise HTTPException(status_code=400, detail="Text must not be empty")
+
+    try:
+        return analyze_text(request.text, db)
+    except SQLAlchemyError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail="Database error") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc


### PR DESCRIPTION
## Summary
- add input and database error handling to text analysis endpoint
- mark Text Analysis Endpoints as complete in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689544510bfc8330bacf9557a5c3c587