### PR TITLE
feat: add confirmation before populating DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ pip install -r api/requirements.txt
 pytest
 ```
 
+## Database Population
+
+Populate the database with the initial word and phrase data:
+
+```bash
+python db/populate_db.py
+```
+
+The script will prompt for confirmation before inserting records. Use the `--force` flag or the `POPULATE_DB_FORCE=1` environment variable to bypass the prompt in automated environments:
+
+```bash
+python db/populate_db.py --force
+# or
+POPULATE_DB_FORCE=1 python db/populate_db.py
+```
+
 ## pgAdmin
 
 - URL: <http://localhost:5050>
@@ -54,5 +70,5 @@ pytest
 - [x] Testing with Pytest
 - [ ] Deploy API
 - [ ] Set DB to cloud
-- [ ] Prompt before populate DB
+- [x] Prompt before populate DB
 

--- a/db/docker-entrypoint.sh
+++ b/db/docker-entrypoint.sh
@@ -21,7 +21,7 @@ log "PostgreSQL is ready. Running populate_db.py..."
 
 # Activate the virtual environment and run the populate script
 . /opt/venv/bin/activate && \
-python3 /docker-entrypoint-initdb.d/populate_db.py
+python3 /docker-entrypoint-initdb.d/populate_db.py --force
 
 log "populate_db.py has completed. PostgreSQL setup is complete."
 

--- a/db/populate_db.py
+++ b/db/populate_db.py
@@ -1,7 +1,9 @@
 """Module to populate the database with the words and phrases data from the JSON files."""
 from contextlib import contextmanager
+import argparse
 import json
 import os
+import sys
 import time
 import logging
 import psycopg2
@@ -63,8 +65,8 @@ def insert_data(conn, table, data):
     finally:
         cur.close()
 
-def main():
-    """Main function to populate the database."""
+def populate_database():
+    """Populate the database with data from JSON files."""
     retry_count = 0
     max_retries = 5
     while retry_count < max_retries:
@@ -86,6 +88,30 @@ def main():
             break
     else:
         logging.error("Max retries reached. Could not connect to the database.")
+
+
+def main():
+    """Entry point for the populate_db script."""
+    parser = argparse.ArgumentParser(description="Populate the database with initial data")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass confirmation prompt and run without asking",
+    )
+    args = parser.parse_args()
+
+    env_force = os.getenv("POPULATE_DB_FORCE", "").lower() in {"1", "true", "yes"}
+    force = args.force or env_force
+
+    if not force:
+        response = input(
+            "This will insert sample data into the database. Continue? [y/N]: "
+        ).strip().lower()
+        if response not in {"y", "yes"}:
+            print("Aborted.")
+            sys.exit(0)
+
+    populate_database()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- require explicit confirmation before inserting seed data
- support `--force` flag or `POPULATE_DB_FORCE` env var to skip prompt
- document database population workflow

## Testing
- `pip install -r api/requirements.txt`
- `pytest`