### PR TITLE
Add production deployment configuration and workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,25 @@
+name: Build and Run API Docker image
+
+on:
+  push:
+    paths:
+      - 'api/**'
+      - '.github/workflows/docker.yml'
+  pull_request:
+    paths:
+      - 'api/**'
+      - '.github/workflows/docker.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build API image
+        run: docker build -t is-replicant-api -f api/Dockerfile api
+      - name: Run container
+        run: |
+          docker run -d --rm --name api -e DATABASE_URL=sqlite:///./test.db -e SECRET_KEY=test -p 8000:8000 is-replicant-api
+          sleep 10
+          curl --fail http://localhost:8000/ || (docker logs api && exit 1)
+          docker stop api

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ Swagger documentation:
 - ReDoc: <http://localhost:8000/api/v1/redoc>
 - OpenAPI JSON: <http://localhost:8000/api/v1/openapi.json>
 
+## Production Deployment
+
+Build a standalone API image and run it with an environment file:
+
+```bash
+cp api/.env.example api/.env  # update values for your environment
+docker build -t is-replicant-api -f api/Dockerfile api
+docker run --env-file api/.env -p 8000:8000 is-replicant-api
+```
+
+The repository includes a sample GitHub Actions workflow in
+`.github/workflows/docker.yml` that builds the container and starts it with
+temporary environment variables.
+
 ## Testing
 
 Install dependencies and run the test suite:

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+*.pyc
+.env
+.env.*
+tests

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for is-Replicant API
+DATABASE_URL=postgresql://user:password@db:5432/is_replicant
+SECRET_KEY=change-me
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,38 +1,23 @@
-# Use a slim variant of Python for smaller image size
-FROM python:3.12-slim
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim AS base
 
-# Set the working directory
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
-# Copy the requirements file first to leverage Docker cache
 COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt && \
+    addgroup --system appgroup && \
+    adduser --system --ingroup appgroup appuser && \
+    mkdir -p /app/nltk_data && \
+    python -m nltk.downloader -d /app/nltk_data punkt
 
-# Install dependencies
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Create a non-root user and group
-RUN addgroup --system appgroup && adduser --system appuser --ingroup appgroup
-
-# Create the NLTK data directory
-RUN mkdir -p /app/nltk_data
-
-# Download NLTK data
-RUN python -m nltk.downloader -d /app/nltk_data punkt
-
-# Set proper permissions
-RUN chown -R appuser:appgroup /app
-
-# Copy the application code
 COPY ./app /app/app
 
-# Set the non-root user to run the application
 USER appuser
-
-# Set environment variable for NLTK data directory
 ENV NLTK_DATA=/app/nltk_data
 
-# Expose the port FastAPI will run on
 EXPOSE 8000
 
-# Default command to run the application
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- Replace API Dockerfile with production-ready setup using non-root user and NLTK data
- Document how to build and run the API container in production
- Provide env template, docker ignore, and CI workflow that builds and runs the container

## Testing
- `pytest`
- `docker version` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6895527ee62483308049b539d4f4df5b